### PR TITLE
Add block pruning functionality

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -27,6 +27,7 @@ testScripts=(
     'mempool_coinbase_spends.py'
     'httpbasics.py'
     'zapwallettxes.py'
+    'proxy_test.py'
 #    'forknotify.py'
 );
 if [ "x${ENABLE_BITCOIND}${ENABLE_UTILS}${ENABLE_WALLET}" = "x111" ]; then

--- a/qa/rpc-tests/proxy_test.py
+++ b/qa/rpc-tests/proxy_test.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python2
+# Copyright (c) 2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+import socket
+import traceback, sys
+from binascii import hexlify
+import time, os
+
+from socks5 import Socks5Configuration, Socks5Command, Socks5Server, AddressType
+from test_framework import BitcoinTestFramework
+from util import *
+'''
+Test plan:
+- Start bitcoind's with different proxy configurations
+- Use addnode to initiate connections
+- Verify that proxies are connected to, and the right connection command is given
+- Proxy configurations to test on bitcoind side:
+    - `-proxy` (proxy everything)
+    - `-onion` (proxy just onions)
+    - `-proxyrandomize` Circuit randomization
+- Proxy configurations to test on proxy side,
+    - support no authentication (other proxy)
+    - support no authentication + user/pass authentication (Tor)
+    - proxy on IPv6
+
+- Create various proxies (as threads)
+- Create bitcoinds that connect to them
+- Manipulate the bitcoinds using addnode (onetry) an observe effects
+
+addnode connect to IPv4
+addnode connect to IPv6
+addnode connect to onion
+addnode connect to generic DNS name
+'''
+
+class ProxyTest(BitcoinTestFramework):        
+    def __init__(self):
+        # Create two proxies on different ports
+        # ... one unauthenticated
+        self.conf1 = Socks5Configuration()
+        self.conf1.addr = ('127.0.0.1', 13000 + (os.getpid() % 1000))
+        self.conf1.unauth = True
+        self.conf1.auth = False
+        # ... one supporting authenticated and unauthenticated (Tor)
+        self.conf2 = Socks5Configuration()
+        self.conf2.addr = ('127.0.0.1', 14000 + (os.getpid() % 1000))
+        self.conf2.unauth = True
+        self.conf2.auth = True
+        # ... one on IPv6 with similar configuration
+        self.conf3 = Socks5Configuration()
+        self.conf3.af = socket.AF_INET6
+        self.conf3.addr = ('::1', 15000 + (os.getpid() % 1000))
+        self.conf3.unauth = True
+        self.conf3.auth = True
+
+        self.serv1 = Socks5Server(self.conf1)
+        self.serv1.start()
+        self.serv2 = Socks5Server(self.conf2)
+        self.serv2.start()
+        self.serv3 = Socks5Server(self.conf3)
+        self.serv3.start()
+
+    def setup_nodes(self):
+        # Note: proxies are not used to connect to local nodes
+        # this is because the proxy to use is based on CService.GetNetwork(), which return NET_UNROUTABLE for localhost
+        return start_nodes(4, self.options.tmpdir, extra_args=[
+            ['-listen', '-debug=net', '-debug=proxy', '-proxy=%s:%i' % (self.conf1.addr),'-proxyrandomize=1'], 
+            ['-listen', '-debug=net', '-debug=proxy', '-proxy=%s:%i' % (self.conf1.addr),'-onion=%s:%i' % (self.conf2.addr),'-proxyrandomize=0'], 
+            ['-listen', '-debug=net', '-debug=proxy', '-proxy=%s:%i' % (self.conf2.addr),'-proxyrandomize=1'], 
+            ['-listen', '-debug=net', '-debug=proxy', '-proxy=[%s]:%i' % (self.conf3.addr),'-proxyrandomize=0']
+            ])
+
+    def node_test(self, node, proxies, auth):
+        rv = []
+        # Test: outgoing IPv4 connection through node
+        node.addnode("15.61.23.23:1234", "onetry")
+        cmd = proxies[0].queue.get()
+        assert(isinstance(cmd, Socks5Command))
+        # Note: bitcoind's SOCKS5 implementation only sends atyp DOMAINNAME, even if connecting directly to IPv4/IPv6
+        assert_equal(cmd.atyp, AddressType.DOMAINNAME)
+        assert_equal(cmd.addr, "15.61.23.23")
+        assert_equal(cmd.port, 1234)
+        if not auth:
+            assert_equal(cmd.username, None)
+            assert_equal(cmd.password, None)
+        rv.append(cmd)
+
+        # Test: outgoing IPv6 connection through node
+        node.addnode("[1233:3432:2434:2343:3234:2345:6546:4534]:5443", "onetry")
+        cmd = proxies[1].queue.get()
+        assert(isinstance(cmd, Socks5Command))
+        # Note: bitcoind's SOCKS5 implementation only sends atyp DOMAINNAME, even if connecting directly to IPv4/IPv6
+        assert_equal(cmd.atyp, AddressType.DOMAINNAME)
+        assert_equal(cmd.addr, "1233:3432:2434:2343:3234:2345:6546:4534")
+        assert_equal(cmd.port, 5443)
+        if not auth:
+            assert_equal(cmd.username, None)
+            assert_equal(cmd.password, None)
+        rv.append(cmd)
+
+        # Test: outgoing onion connection through node
+        node.addnode("bitcoinostk4e4re.onion:8333", "onetry")
+        cmd = proxies[2].queue.get()
+        assert(isinstance(cmd, Socks5Command))
+        assert_equal(cmd.atyp, AddressType.DOMAINNAME)
+        assert_equal(cmd.addr, "bitcoinostk4e4re.onion")
+        assert_equal(cmd.port, 8333)
+        if not auth:
+            assert_equal(cmd.username, None)
+            assert_equal(cmd.password, None)
+        rv.append(cmd)
+
+        # Test: outgoing DNS name connection through node
+        node.addnode("node.noumenon:8333", "onetry")
+        cmd = proxies[3].queue.get()
+        assert(isinstance(cmd, Socks5Command))
+        assert_equal(cmd.atyp, AddressType.DOMAINNAME)
+        assert_equal(cmd.addr, "node.noumenon")
+        assert_equal(cmd.port, 8333)
+        if not auth:
+            assert_equal(cmd.username, None)
+            assert_equal(cmd.password, None)
+        rv.append(cmd)
+
+        return rv
+
+    def run_test(self):
+        # basic -proxy
+        self.node_test(self.nodes[0], [self.serv1, self.serv1, self.serv1, self.serv1], False)
+
+        # -proxy plus -onion
+        self.node_test(self.nodes[1], [self.serv1, self.serv1, self.serv2, self.serv1], False)
+
+        # -proxy plus -onion, -proxyrandomize
+        rv = self.node_test(self.nodes[2], [self.serv2, self.serv2, self.serv2, self.serv2], True)
+        # Check that credentials as used for -proxyrandomize connections are unique
+        credentials = set((x.username,x.password) for x in rv)
+        assert_equal(len(credentials), 4)
+
+        # proxy on IPv6 localhost
+        self.node_test(self.nodes[3], [self.serv3, self.serv3, self.serv3, self.serv3], False)
+        
+if __name__ == '__main__':
+    ProxyTest().main()
+

--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test pruning code
+# ********
+# WARNING:
+# This test uses 4GB of disk space and takes in excess of 30 mins to run
+# ********
+
+from test_framework import BitcoinTestFramework
+from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
+from util import *
+import os.path
+
+def calc_usage(blockdir):
+    return sum(os.path.getsize(blockdir+f) for f in os.listdir(blockdir) if os.path.isfile(blockdir+f))/(1024*1024)
+
+class PruneTest(BitcoinTestFramework):
+
+    def __init__(self):
+        self.utxo = []
+        self.address = ["",""]
+
+        # Some pre-processing to create a bunch of OP_RETURN txouts to insert into transactions we create
+        # So we have big transactions and full blocks to fill up our block files
+
+        # create one script_pubkey
+        script_pubkey = "6a4d0200" #OP_RETURN OP_PUSH2 512 bytes
+        for i in xrange (512):
+            script_pubkey = script_pubkey + "01"
+        # concatenate 128 txouts of above script_pubkey which we'll insert before the txout for change
+        self.txouts = "81"
+        for k in xrange(128):
+            # add txout value
+            self.txouts = self.txouts + "0000000000000000"
+            # add length of script_pubkey
+            self.txouts = self.txouts + "fd0402"
+            # add script_pubkey
+            self.txouts = self.txouts + script_pubkey
+
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 3)
+
+    def setup_network(self):
+        self.nodes = []
+        self.is_network_split = False
+
+        # Create nodes 0 and 1 to mine
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=999000", "-checkblocks=5"], timewait=300))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=999000", "-checkblocks=5"], timewait=300))
+
+        # Create node 2 to test pruning
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-prune=550"], timewait=300))
+        self.prunedir = self.options.tmpdir+"/node2/regtest/blocks/"
+
+        self.address[0] = self.nodes[0].getnewaddress()
+        self.address[1] = self.nodes[1].getnewaddress()
+
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[1], 2)
+        connect_nodes(self.nodes[2], 0)
+        sync_blocks(self.nodes[0:3])
+
+    def create_big_chain(self):
+        # Start by creating some coinbases we can spend later
+        self.nodes[1].generate(200)
+        sync_blocks(self.nodes[0:2])
+        self.nodes[0].generate(150)
+        # Then mine enough full blocks to create more than 550MB of data
+        for i in xrange(645):
+            self.mine_full_block(self.nodes[0], self.address[0])
+
+        sync_blocks(self.nodes[0:3])
+
+    def test_height_min(self):
+        if not os.path.isfile(self.prunedir+"blk00000.dat"):
+            raise AssertionError("blk00000.dat is missing, pruning too early")
+        print "Success"
+        print "Though we're already using more than 550MB, current usage:", calc_usage(self.prunedir)
+        print "Mining 25 more blocks should cause the first block file to be pruned"
+        # Pruning doesn't run until we're allocating another chunk, 20 full blocks past the height cutoff will ensure this
+        for i in xrange(25):
+            self.mine_full_block(self.nodes[0],self.address[0])
+
+        waitstart = time.time()
+        while os.path.isfile(self.prunedir+"blk00000.dat"):
+            time.sleep(0.1)
+            if time.time() - waitstart > 10:
+                raise AssertionError("blk00000.dat not pruned when it should be")
+
+        print "Success"
+        usage = calc_usage(self.prunedir)
+        print "Usage should be below target:", usage
+        if (usage > 550):
+            raise AssertionError("Pruning target not being met")
+
+    def create_chain_with_staleblocks(self):
+        # Create stale blocks in manageable sized chunks
+        print "Mine 24 (stale) blocks on Node 1, followed by 25 (main chain) block reorg from Node 0, for 12 rounds"
+
+        for j in xrange(12):
+            # Disconnect node 0 so it can mine a longer reorg chain without knowing about node 1's soon-to-be-stale chain
+            # Node 2 stays connected, so it hears about the stale blocks and then reorg's when node0 reconnects
+            # Stopping node 0 also clears its mempool, so it doesn't have node1's transactions to accidentally mine
+            stop_node(self.nodes[0],0)
+            self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=999000", "-checkblocks=5"], timewait=300)
+            # Mine 24 blocks in node 1
+            self.utxo = self.nodes[1].listunspent()
+            for i in xrange(24):
+                if j == 0:
+                    self.mine_full_block(self.nodes[1],self.address[1])
+                else:
+                    self.nodes[1].generate(1) #tx's already in mempool from previous disconnects
+
+            # Reorg back with 25 block chain from node 0
+            self.utxo = self.nodes[0].listunspent()
+            for i in xrange(25): 
+                self.mine_full_block(self.nodes[0],self.address[0])
+
+            # Create connections in the order so both nodes can see the reorg at the same time
+            connect_nodes(self.nodes[1], 0)
+            connect_nodes(self.nodes[2], 0)
+            sync_blocks(self.nodes[0:3])
+
+        print "Usage can be over target because of high stale rate:", calc_usage(self.prunedir)
+
+    def reorg_test(self):
+        # Node 1 will mine a 300 block chain starting 287 blocks back from Node 0 and Node 2's tip
+        # This will cause Node 2 to do a reorg requiring 288 blocks of undo data to the reorg_test chain
+        # Reboot node 1 to clear its mempool (hopefully make the invalidate faster)
+        # Lower the block max size so we don't keep mining all our big mempool transactions (from disconnected blocks)
+        stop_node(self.nodes[1],1)
+        self.nodes[1]=start_node(1, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=5000", "-checkblocks=5", "-disablesafemode"], timewait=300)
+
+        height = self.nodes[1].getblockcount()
+        print "Current block height:", height
+
+        invalidheight = height-287
+        badhash = self.nodes[1].getblockhash(invalidheight)
+        print "Invalidating block at height:",invalidheight,badhash
+        self.nodes[1].invalidateblock(badhash)
+
+        # We've now switched to our previously mined-24 block fork on node 1, but thats not what we want
+        # So invalidate that fork as well, until we're on the same chain as node 0/2 (but at an ancestor 288 blocks ago)
+        mainchainhash = self.nodes[0].getblockhash(invalidheight - 1)
+        curhash = self.nodes[1].getblockhash(invalidheight - 1)
+        while curhash != mainchainhash:
+            self.nodes[1].invalidateblock(curhash)
+            curhash = self.nodes[1].getblockhash(invalidheight - 1)
+
+        assert(self.nodes[1].getblockcount() == invalidheight - 1)
+        print "New best height", self.nodes[1].getblockcount()
+
+        # Reboot node1 to clear those giant tx's from mempool
+        stop_node(self.nodes[1],1)
+        self.nodes[1]=start_node(1, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=5000", "-checkblocks=5", "-disablesafemode"], timewait=300)
+
+        print "Generating new longer chain of 300 more blocks"
+        self.nodes[1].generate(300)
+
+        print "Reconnect nodes"
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[2], 1)
+        sync_blocks(self.nodes[0:3])
+
+        print "Verify height on node 2:",self.nodes[2].getblockcount()
+        print "Usage possibly still high bc of stale blocks in block files:", calc_usage(self.prunedir)
+
+        print "Mine 220 more blocks so we have requisite history (some blocks will be big and cause pruning of previous chain)"
+        self.nodes[0].generate(220) #node 0 has many large tx's in its mempool from the disconnects
+        sync_blocks(self.nodes[0:3])
+
+        usage = calc_usage(self.prunedir)
+        print "Usage should be below target:", usage
+        if (usage > 550):
+            raise AssertionError("Pruning target not being met")
+
+        return invalidheight,badhash
+
+    def reorg_back(self):
+        # Verify that a block on the old main chain fork has been pruned away
+        try:
+            self.nodes[2].getblock(self.forkhash)
+            raise AssertionError("Old block wasn't pruned so can't test redownload")
+        except JSONRPCException as e:
+            print "Will need to redownload block",self.forkheight
+
+        # Verify that we have enough history to reorg back to the fork point
+        # Although this is more than 288 blocks, because this chain was written more recently
+        # and only its other 299 small and 220 large block are in the block files after it,
+        # its expected to still be retained
+        self.nodes[2].getblock(self.nodes[2].getblockhash(self.forkheight))
+
+        first_reorg_height = self.nodes[2].getblockcount()
+        curchainhash = self.nodes[2].getblockhash(self.mainchainheight)
+        self.nodes[2].invalidateblock(curchainhash)
+        goalbestheight = self.mainchainheight
+        goalbesthash = self.mainchainhash2
+
+        # As of 0.10 the current block download logic is not able to reorg to the original chain created in
+        # create_chain_with_stale_blocks because it doesn't know of any peer thats on that chain from which to
+        # redownload its missing blocks.
+        # Invalidate the reorg_test chain in node 0 as well, it can successfully switch to the original chain
+        # because it has all the block data.
+        # However it must mine enough blocks to have a more work chain than the reorg_test chain in order
+        # to trigger node 2's block download logic.
+        # At this point node 2 is within 288 blocks of the fork point so it will preserve its ability to reorg
+        if self.nodes[2].getblockcount() < self.mainchainheight:
+            blocks_to_mine = first_reorg_height + 1 - self.mainchainheight
+            print "Rewind node 0 to prev main chain to mine longer chain to trigger redownload. Blocks needed:", blocks_to_mine
+            self.nodes[0].invalidateblock(curchainhash)
+            assert(self.nodes[0].getblockcount() == self.mainchainheight)
+            assert(self.nodes[0].getbestblockhash() == self.mainchainhash2)
+            goalbesthash = self.nodes[0].generate(blocks_to_mine)[-1]
+            goalbestheight = first_reorg_height + 1
+
+        print "Verify node 2 reorged back to the main chain, some blocks of which it had to redownload"
+        waitstart = time.time()
+        while self.nodes[2].getblockcount() < goalbestheight:
+            time.sleep(0.1)
+            if time.time() - waitstart > 300:
+                raise AssertionError("Node 2 didn't reorg to proper height")
+        assert(self.nodes[2].getbestblockhash() == goalbesthash)
+        # Verify we can now have the data for a block previously pruned
+        assert(self.nodes[2].getblock(self.forkhash)["height"] == self.forkheight)
+
+    def mine_full_block(self, node, address):
+        # Want to create a full block
+        # We'll generate a 66k transaction below, and 14 of them is close to the 1MB block limit
+        for j in xrange(14):
+            if len(self.utxo) < 14:
+                self.utxo = node.listunspent()
+            inputs=[]
+            outputs = {}
+            t = self.utxo.pop()
+            inputs.append({ "txid" : t["txid"], "vout" : t["vout"]})
+            remchange = t["amount"] - Decimal("0.001000")
+            outputs[address]=remchange
+            # Create a basic transaction that will send change back to ourself after account for a fee
+            # And then insert the 128 generated transaction outs in the middle rawtx[92] is where the #
+            # of txouts is stored and is the only thing we overwrite from the original transaction
+            rawtx = node.createrawtransaction(inputs, outputs)
+            newtx = rawtx[0:92]
+            newtx = newtx + self.txouts
+            newtx = newtx + rawtx[94:]
+            # Appears to be ever so slightly faster to sign with SIGHASH_NONE
+            signresult = node.signrawtransaction(newtx,None,None,"NONE")
+            txid = node.sendrawtransaction(signresult["hex"], True)
+        # Mine a full sized block which will be these transactions we just created
+        node.generate(1)
+
+
+    def run_test(self):
+        print "Warning! This test requires 4GB of disk space and takes over 30 mins"
+        print "Mining a big blockchain of 995 blocks"
+        self.create_big_chain()
+        # Chain diagram key:
+        # *   blocks on main chain
+        # +,&,$,@ blocks on other forks
+        # X   invalidated block
+        # N1  Node 1
+        #
+        # Start by mining a simple chain that all nodes have
+        # N0=N1=N2 **...*(995)
+
+        print "Check that we haven't started pruning yet because we're below PruneAfterHeight"
+        self.test_height_min()
+        # Extend this chain past the PruneAfterHeight
+        # N0=N1=N2 **...*(1020)
+
+        print "Check that we'll exceed disk space target if we have a very high stale block rate"
+        self.create_chain_with_staleblocks()
+        # Disconnect N0
+        # And mine a 24 block chain on N1 and a separate 25 block chain on N0
+        # N1=N2 **...*+...+(1044)
+        # N0    **...**...**(1045)
+        #
+        # reconnect nodes causing reorg on N1 and N2
+        # N1=N2 **...*(1020) *...**(1045)
+        #                   \
+        #                    +...+(1044)
+        #
+        # repeat this process until you have 12 stale forks hanging off the
+        # main chain on N1 and N2
+        # N0    *************************...***************************(1320)
+        #
+        # N1=N2 **...*(1020) *...**(1045) *..         ..**(1295) *...**(1320)
+        #                   \            \                      \
+        #                    +...+(1044)  &..                    $...$(1319)
+
+        # Save some current chain state for later use
+        self.mainchainheight = self.nodes[2].getblockcount()   #1320
+        self.mainchainhash2 = self.nodes[2].getblockhash(self.mainchainheight)
+
+        print "Check that we can survive a 288 block reorg still"
+        (self.forkheight,self.forkhash) = self.reorg_test() #(1033, )
+        # Now create a 288 block reorg by mining a longer chain on N1
+        # First disconnect N1
+        # Then invalidate 1033 on main chain and 1032 on fork so height is 1032 on main chain
+        # N1   **...*(1020) **...**(1032)X..
+        #                  \
+        #                   ++...+(1031)X..
+        #
+        # Now mine 300 more blocks on N1
+        # N1    **...*(1020) **...**(1032) @@...@(1332)
+        #                 \               \
+        #                  \               X...
+        #                   \                 \
+        #                    ++...+(1031)X..   ..
+        #
+        # Reconnect nodes and mine 220 more blocks on N1
+        # N1    **...*(1020) **...**(1032) @@...@@@(1552)
+        #                 \               \
+        #                  \               X...
+        #                   \                 \
+        #                    ++...+(1031)X..   ..
+        #
+        # N2    **...*(1020) **...**(1032) @@...@@@(1552)
+        #                 \               \
+        #                  \               *...**(1320)
+        #                   \                 \
+        #                    ++...++(1044)     ..
+        #
+        # N0    ********************(1032) @@...@@@(1552) 
+        #                                 \
+        #                                  *...**(1320)
+
+        print "Test that we can rerequest a block we previously pruned if needed for a reorg"
+        self.reorg_back()
+        # Verify that N2 still has block 1033 on current chain (@), but not on main chain (*)
+        # Invalidate 1033 on current chain (@) on N2 and we should be able to reorg to
+        # original main chain (*), but will require redownload of some blocks
+        # In order to have a peer we think we can download from, must also perform this invalidation
+        # on N0 and mine a new longest chain to trigger.
+        # Final result:
+        # N0    ********************(1032) **...****(1553)
+        #                                 \
+        #                                  X@...@@@(1552)
+        #
+        # N2    **...*(1020) **...**(1032) **...****(1553)
+        #                 \               \
+        #                  \               X@...@@@(1552)
+        #                   \
+        #                    +..
+        #
+        # N1 doesn't change because 1033 on main chain (*) is invalid
+
+        print "Done"
+
+if __name__ == '__main__':
+    PruneTest().main()

--- a/qa/rpc-tests/socks5.py
+++ b/qa/rpc-tests/socks5.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+'''
+Dummy Socks5 server for testing.
+'''
+from __future__ import print_function, division, unicode_literals
+import socket, threading, Queue
+import traceback, sys
+
+### Protocol constants
+class Command:
+    CONNECT = 0x01
+
+class AddressType:
+    IPV4 = 0x01
+    DOMAINNAME = 0x03
+    IPV6 = 0x04
+
+### Utility functions
+def recvall(s, n):
+    '''Receive n bytes from a socket, or fail'''
+    rv = bytearray()
+    while n > 0:
+        d = s.recv(n)
+        if not d:
+            raise IOError('Unexpected end of stream')
+        rv.extend(d)
+        n -= len(d)
+    return rv
+
+### Implementation classes
+class Socks5Configuration(object):
+    '''Proxy configuration'''
+    def __init__(self):
+        self.addr = None # Bind address (must be set)
+        self.af = socket.AF_INET # Bind address family
+        self.unauth = False  # Support unauthenticated
+        self.auth = False  # Support authentication
+
+class Socks5Command(object):
+    '''Information about an incoming socks5 command'''
+    def __init__(self, cmd, atyp, addr, port, username, password):
+        self.cmd = cmd # Command (one of Command.*)
+        self.atyp = atyp # Address type (one of AddressType.*)
+        self.addr = addr # Address
+        self.port = port # Port to connect to
+        self.username = username
+        self.password = password
+    def __repr__(self):
+        return 'Socks5Command(%s,%s,%s,%s,%s,%s)' % (self.cmd, self.atyp, self.addr, self.port, self.username, self.password)
+
+class Socks5Connection(object):
+    def __init__(self, serv, conn, peer):
+        self.serv = serv
+        self.conn = conn
+        self.peer = peer
+
+    def handle(self):
+        '''
+        Handle socks5 request according to RFC1928
+        '''
+        try:
+            # Verify socks version
+            ver = recvall(self.conn, 1)[0]
+            if ver != 0x05:
+                raise IOError('Invalid socks version %i' % ver)
+            # Choose authentication method
+            nmethods = recvall(self.conn, 1)[0]
+            methods = bytearray(recvall(self.conn, nmethods))
+            method = None
+            if 0x02 in methods and self.serv.conf.auth:
+                method = 0x02 # username/password
+            elif 0x00 in methods and self.serv.conf.unauth:
+                method = 0x00 # unauthenticated
+            if method is None:
+                raise IOError('No supported authentication method was offered')
+            # Send response
+            self.conn.sendall(bytearray([0x05, method]))
+            # Read authentication (optional)
+            username = None
+            password = None
+            if method == 0x02:
+                ver = recvall(self.conn, 1)[0]
+                if ver != 0x01:
+                    raise IOError('Invalid auth packet version %i' % ver)
+                ulen = recvall(self.conn, 1)[0]
+                username = str(recvall(self.conn, ulen))
+                plen = recvall(self.conn, 1)[0]
+                password = str(recvall(self.conn, plen))
+                # Send authentication response
+                self.conn.sendall(bytearray([0x01, 0x00]))
+
+            # Read connect request
+            (ver,cmd,rsv,atyp) = recvall(self.conn, 4)
+            if ver != 0x05:
+                raise IOError('Invalid socks version %i in connect request' % ver)
+            if cmd != Command.CONNECT:
+                raise IOError('Unhandled command %i in connect request' % cmd)
+
+            if atyp == AddressType.IPV4:
+                addr = recvall(self.conn, 4)
+            elif atyp == AddressType.DOMAINNAME:
+                n = recvall(self.conn, 1)[0]
+                addr = str(recvall(self.conn, n))
+            elif atyp == AddressType.IPV6:
+                addr = recvall(self.conn, 16)
+            else:
+                raise IOError('Unknown address type %i' % atyp)
+            port_hi,port_lo = recvall(self.conn, 2)
+            port = (port_hi << 8) | port_lo
+
+            # Send dummy response
+            self.conn.sendall(bytearray([0x05, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+
+            cmdin = Socks5Command(cmd, atyp, addr, port, username, password)
+            self.serv.queue.put(cmdin)
+            print('Proxy: ', cmdin)
+            # Fall through to disconnect
+        except Exception,e:
+            traceback.print_exc(file=sys.stderr)
+            self.serv.queue.put(e)
+        finally:
+            self.conn.close()
+
+class Socks5Server(object):
+    def __init__(self, conf):
+        self.conf = conf
+        self.s = socket.socket(conf.af)
+        self.s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.s.bind(conf.addr)
+        self.s.listen(5)
+        self.running = False
+        self.thread = None
+        self.queue = Queue.Queue() # report connections and exceptions to client
+
+    def run(self):
+        while self.running:
+            (sockconn, peer) = self.s.accept()
+            if self.running:
+                conn = Socks5Connection(self, sockconn, peer)
+                thread = threading.Thread(None, conn.handle)
+                thread.daemon = True
+                thread.start()
+    
+    def start(self):
+        assert(not self.running)
+        self.running = True
+        self.thread = threading.Thread(None, self.run)
+        self.thread.daemon = True
+        self.thread.start()
+
+    def stop(self):
+        self.running = False
+        # connect to self to end run loop
+        s = socket.socket(self.conf.af)
+        s.connect(self.conf.addr)
+        s.close()
+        self.thread.join()
+

--- a/qa/rpc-tests/util.py
+++ b/qa/rpc-tests/util.py
@@ -158,7 +158,7 @@ def _rpchost_to_args(rpchost):
         rv += ['-rpcport=' + rpcport]
     return rv
 
-def start_node(i, dirname, extra_args=None, rpchost=None):
+def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None):
     """
     Start a bitcoind and return RPC connection to it
     """
@@ -172,7 +172,10 @@ def start_node(i, dirname, extra_args=None, rpchost=None):
                           ["-rpcwait", "getblockcount"], stdout=devnull)
     devnull.close()
     url = "http://rt:rt@%s:%d" % (rpchost or '127.0.0.1', rpc_port(i))
-    proxy = AuthServiceProxy(url)
+    if timewait is not None:
+        proxy = AuthServiceProxy(url, timeout=timewait)
+    else:
+        proxy = AuthServiceProxy(url)
     proxy.url = url # store URL on proxy for info
     return proxy
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -121,6 +121,7 @@ public:
         vAlertPubKey = ParseHex("04fc9702847840aaf195de8442ebecedf5b095cdbb9bc716bda9110971b28a49e0ead8564ff0db22209e0374782c093bb899692d524e9d6a6956e7c5ecbcd68284");
         nDefaultPort = 8333;
         nMinerThreads = 0;
+        nPruneAfterHeight = 100000;
 
         /**
          * Build the genesis block. Note that the output of the genesis coinbase cannot
@@ -198,6 +199,7 @@ public:
         vAlertPubKey = ParseHex("04302390343f91cc401d56d68b123028bf52e5fca1939df127f63c6467cdf9c8e2c14b61104cf817d0b780da337893ecc4aaff1309e536162dabbdb45200ca2b0a");
         nDefaultPort = 18333;
         nMinerThreads = 0;
+        nPruneAfterHeight = 1000;
 
         //! Modify the testnet genesis block so the timestamp is valid for a later start.
         genesis.nTime = 1296688602;
@@ -257,6 +259,7 @@ public:
         consensus.hashGenesisBlock = genesis.GetHash();
         nDefaultPort = 18444;
         assert(consensus.hashGenesisBlock == uint256S("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
+        nPruneAfterHeight = 1000;
 
         vFixedSeeds.clear(); //! Regtest mode doesn't have any fixed seeds.
         vSeeds.clear();  //! Regtest mode doesn't have any DNS seeds.

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -58,6 +58,7 @@ public:
     bool DefaultConsistencyChecks() const { return fDefaultConsistencyChecks; }
     /** Make standard checks */
     bool RequireStandard() const { return fRequireStandard; }
+    int64_t PruneAfterHeight() const { return nPruneAfterHeight; }
     /** Make miner stop after a block is found. In RPC, don't return until nGenProcLimit blocks are generated */
     bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
     /** In the future use NetworkIDString() for RPC fields */
@@ -77,6 +78,7 @@ protected:
     std::vector<unsigned char> vAlertPubKey;
     int nDefaultPort;
     int nMinerThreads;
+    uint64_t nPruneAfterHeight;
     std::vector<CDNSSeedData> vSeeds;
     std::vector<unsigned char> base58Prefixes[MAX_BASE58_TYPES];
     std::string strNetworkID;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -275,7 +275,12 @@ std::string HelpMessage(HelpMessageMode mode)
 #ifndef WIN32
     strUsage += HelpMessageOpt("-pid=<file>", strprintf(_("Specify pid file (default: %s)"), "bitcoind.pid"));
 #endif
-    strUsage += HelpMessageOpt("-reindex", _("Rebuild block chain index from current blk000??.dat files") + " " + _("on startup"));
+    strUsage += HelpMessageOpt("-prune=<n>", _("Reduce storage requirements by pruning (deleting) old blocks. This mode disables wallet support and is incompatible with -txindex.") + " " +
+            _("Warning: Reverting this setting requires re-downloading the entire blockchain.") + " " +
+            _("(default: 0 = disable pruning blocks,") + " " +
+            strprintf(_(">%u = target size in MiB to use for block files)"), MIN_DISK_SPACE_FOR_BLOCK_FILES / 1024 / 1024));
+strUsage += HelpMessageOpt("-reindex", _("Rebuild block chain index from current blk000??.dat files") + " " + _("on startup"));
+
 #if !defined(WIN32)
     strUsage += HelpMessageOpt("-sysperms", _("Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)"));
 #endif
@@ -352,7 +357,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-flushwallet", strprintf(_("Run a thread to flush wallet periodically (default: %u)"), 1));
         strUsage += HelpMessageOpt("-stopafterblockimport", strprintf(_("Stop running after importing blocks from disk (default: %u)"), 0));
     }
-    string debugCategories = "addrman, alert, bench, coindb, db, lock, rand, rpc, selectcoins, mempool, net, proxy"; // Don't translate these and qt below
+    string debugCategories = "addrman, alert, bench, coindb, db, lock, rand, rpc, selectcoins, mempool, net, proxy, prune"; // Don't translate these and qt below
     if (mode == HMM_BITCOIN_QT)
         debugCategories += ", qt";
     strUsage += HelpMessageOpt("-debug=<category>", strprintf(_("Output debugging information (default: %u, supplying <category> is optional)"), 0) + ". " +
@@ -458,10 +463,33 @@ struct CImportingNow
     }
 };
 
+
+// If we're using -prune with -reindex, then delete block files that will be ignored by the
+// reindex.  Since reindexing works by starting at block file 0 and looping until a blockfile
+// is missing, and since pruning works by deleting the oldest block file first, just check
+// for block file 0, and if it doesn't exist, delete all the block files in the
+// directory (since they won't be read by the reindex but will take up disk space).
+void DeleteAllBlockFiles()
+{
+    if (boost::filesystem::exists(GetBlockPosFilename(CDiskBlockPos(0, 0), "blk")))
+        return;
+
+    LogPrintf("Removing all blk?????.dat and rev?????.dat files for -reindex with -prune\n");
+    boost::filesystem::path blocksdir = GetDataDir() / "blocks";
+    for (boost::filesystem::directory_iterator it(blocksdir); it != boost::filesystem::directory_iterator(); it++) {
+        if (is_regular_file(*it)) {
+            if ((it->path().filename().string().length() == 12) &&
+                (it->path().filename().string().substr(8,4) == ".dat") &&
+                ((it->path().filename().string().substr(0,3) == "blk") ||
+                 (it->path().filename().string().substr(0,3) == "rev")))
+                boost::filesystem::remove(it->path());
+        }
+    }
+}
+
 void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
 {
     RenameThread("bitcoin-loadblk");
-
     // -reindex
     if (fReindex) {
         CImportingNow imp;
@@ -674,6 +702,21 @@ bool AppInit2(boost::thread_group& threadGroup)
     if (nFD - MIN_CORE_FILEDESCRIPTORS < nMaxConnections)
         nMaxConnections = nFD - MIN_CORE_FILEDESCRIPTORS;
 
+    // if using block pruning, then disable txindex
+    // also disable the wallet (for now, until SPV support is implemented in wallet)
+    if (GetArg("-prune", 0)) {
+        if (GetBoolArg("-txindex", false))
+            return InitError(_("Prune mode is incompatible with -txindex."));
+#ifdef ENABLE_WALLET
+        if (!GetBoolArg("-disablewallet", false)) {
+            if (SoftSetBoolArg("-disablewallet", true))
+                LogPrintf("%s : parameter interaction: -prune -> setting -disablewallet=1\n", __func__);
+            else
+                return InitError(_("Can't run with a wallet in prune mode."));
+        }
+#endif
+    }
+
     // ********************************************************* Step 3: parameter-to-internal-flags
 
     fDebug = !mapMultiArgs["-debug"].empty();
@@ -710,6 +753,21 @@ bool AppInit2(boost::thread_group& threadGroup)
         nScriptCheckThreads = MAX_SCRIPTCHECK_THREADS;
 
     fServer = GetBoolArg("-server", false);
+
+    // block pruning; get the amount of disk space (in MB) to allot for block & undo files
+    int64_t nSignedPruneTarget = GetArg("-prune", 0) * 1024 * 1024;
+    if (nSignedPruneTarget < 0) {
+        return InitError(_("Prune cannot be configured with a negative value."));
+    }
+    nPruneTarget = (uint64_t) nSignedPruneTarget;
+    if (nPruneTarget) {
+        if (nPruneTarget < MIN_DISK_SPACE_FOR_BLOCK_FILES) {
+            return InitError(strprintf(_("Prune configured below the minimum of %d MB.  Please use a higher number."), MIN_DISK_SPACE_FOR_BLOCK_FILES / 1024 / 1024));
+        }
+        LogPrintf("Prune configured to target %uMiB on disk for block and undo files.\n", nPruneTarget / 1024 / 1024);
+        fPruneMode = true;
+    }
+
 #ifdef ENABLE_WALLET
     bool fDisableWallet = GetBoolArg("-disablewallet", false);
 #endif
@@ -1030,8 +1088,12 @@ bool AppInit2(boost::thread_group& threadGroup)
                 pcoinscatcher = new CCoinsViewErrorCatcher(pcoinsdbview);
                 pcoinsTip = new CCoinsViewCache(pcoinscatcher);
 
-                if (fReindex)
+                if (fReindex) {
                     pblocktree->WriteReindexing(true);
+                    //If we're reindexing in prune mode, wipe away all our block and undo data files
+                    if (fPruneMode)
+                        DeleteAllBlockFiles();
+                }
 
                 if (!LoadBlockIndex()) {
                     strLoadError = _("Error loading block database");
@@ -1055,7 +1117,18 @@ bool AppInit2(boost::thread_group& threadGroup)
                     break;
                 }
 
+                // Check for changed -prune state.  What we are concerned about is a user who has pruned blocks
+                // in the past, but is now trying to run unpruned.
+                if (fHavePruned && !fPruneMode) {
+                    strLoadError = _("You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain");
+                    break;
+                }
+
                 uiInterface.InitMessage(_("Verifying blocks..."));
+                if (fHavePruned && GetArg("-checkblocks", 288) > MIN_BLOCKS_TO_KEEP) {
+                    LogPrintf("Prune: pruned datadir may not have more than %d blocks; -checkblocks=%d may fail\n",
+                        MIN_BLOCKS_TO_KEEP, GetArg("-checkblocks", 288));
+                }
                 if (!CVerifyDB().VerifyDB(pcoinsdbview, GetArg("-checklevel", 3),
                               GetArg("-checkblocks", 288))) {
                     strLoadError = _("Corrupted block database detected");
@@ -1105,6 +1178,15 @@ bool AppInit2(boost::thread_group& threadGroup)
     if (!est_filein.IsNull())
         mempool.ReadFeeEstimates(est_filein);
     fFeeEstimatesInitialized = true;
+
+    // if prune mode, unset NODE_NETWORK and prune block files
+    if (fPruneMode) {
+        LogPrintf("Unsetting NODE_NETWORK on prune mode\n");
+        nLocalServices &= ~NODE_NETWORK;
+        if (!fReindex) {
+            PruneAndFlush();
+        }
+    }
 
     // ********************************************************* Step 8: load wallet
 #ifdef ENABLE_WALLET

--- a/src/main.h
+++ b/src/main.h
@@ -132,6 +132,26 @@ extern CBlockIndex *pindexBestHeader;
 /** Minimum disk space required - used in CheckDiskSpace() */
 static const uint64_t nMinDiskSpace = 52428800;
 
+/** Pruning-related variables and constants */
+/** True if any block files have ever been pruned. */
+extern bool fHavePruned;
+/** True if we're running in -prune mode. */
+extern bool fPruneMode;
+/** Number of MiB of block files that we're trying to stay below. */
+extern uint64_t nPruneTarget;
+/** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of chainActive.Tip() will not be pruned. */
+static const signed int MIN_BLOCKS_TO_KEEP = 288;
+
+// Require that user allocate at least 550MB for block & undo files (blk???.dat and rev???.dat)
+// At 1MB per block, 288 blocks = 288MB.
+// Add 15% for Undo data = 331MB
+// Add 20% for Orphan block rate = 397MB
+// We want the low water mark after pruning to be at least 397 MB and since we prune in
+// full block file chunks, we need the high water mark which triggers the prune to be
+// one 128MB block file + added 15% undo data = 147MB greater for a total of 545MB
+// Setting the target to > than 550MB will make it likely we can respect the target.
+static const signed int MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
+
 /** Register with a network node to receive its signals */
 void RegisterNodeSignals(CNodeSignals& nodeSignals);
 /** Unregister a network node */
@@ -186,6 +206,28 @@ bool GetTransaction(const uint256 &hash, CTransaction &tx, uint256 &hashBlock, b
 bool ActivateBestChain(CValidationState &state, CBlock *pblock = NULL);
 CAmount GetBlockValue(int nHeight, const CAmount& nFees);
 
+/**
+ * Prune block and undo files (blk???.dat and undo???.dat) so that the disk space used is less than a user-defined target.
+ * The user sets the target (in MB) on the command line or in config file.  This will be run on startup and whenever new
+ * space is allocated in a block or undo file, staying below the target. Changing back to unpruned requires a reindex
+ * (which in this case means the blockchain must be re-downloaded.)
+ *
+ * Pruning functions are called from FlushStateToDisk when the global fCheckForPruning flag has been set.
+ * Block and undo files are deleted in lock-step (when blk00003.dat is deleted, so is rev00003.dat.)
+ * Pruning cannot take place until the longest chain is at least a certain length (100000 on mainnet, 1000 on testnet, 10 on regtest).
+ * Pruning will never delete a block within a defined distance (currently 288) from the active chain's tip.
+ * The block index is updated by unsetting HAVE_DATA and HAVE_UNDO for any blocks that were stored in the deleted files.
+ * A db flag records the fact that at least some block files have been pruned.
+ *
+ * @param[out]   setFilesToPrune   The set of file indices that can be unlinked will be returned
+ */
+void FindFilesToPrune(std::set<int>& setFilesToPrune);
+
+/**
+ *  Actually unlink the specified files
+ */
+void UnlinkPrunedFiles(std::set<int>& setFilesToPrune);
+
 /** Create a new block index entry for a given block hash */
 CBlockIndex * InsertBlockIndex(uint256 hash);
 /** Abort with a message */
@@ -196,7 +238,8 @@ bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats);
 void Misbehaving(NodeId nodeid, int howmuch);
 /** Flush all state, indexes and buffers to disk. */
 void FlushStateToDisk();
-
+/** Prune block files and flush state to disk. */
+void PruneAndFlush();
 
 /** (try to) add transaction to memory pool **/
 bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransaction &tx, bool fLimitFree,

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -12,6 +12,7 @@
 #include "hash.h"
 #include "sync.h"
 #include "uint256.h"
+#include "random.h"
 #include "util.h"
 #include "utilstrencodings.h"
 
@@ -38,7 +39,7 @@ using namespace std;
 
 // Settings
 static proxyType proxyInfo[NET_MAX];
-static CService nameProxy;
+static proxyType nameProxy;
 static CCriticalSection cs_proxyInfos;
 int nConnectTimeout = DEFAULT_CONNECT_TIMEOUT;
 bool fNameLookup = false;
@@ -285,59 +286,100 @@ bool static InterruptibleRecv(char* data, size_t len, int timeout, SOCKET& hSock
     return len == 0;
 }
 
-bool static Socks5(string strDest, int port, SOCKET& hSocket)
+struct ProxyCredentials
+{
+    std::string username;
+    std::string password;
+};
+
+/** Connect using SOCKS5 (as described in RFC1928) */
+bool static Socks5(string strDest, int port, const ProxyCredentials *auth, SOCKET& hSocket)
 {
     LogPrintf("SOCKS5 connecting %s\n", strDest);
-    if (strDest.size() > 255)
-    {
+    if (strDest.size() > 255) {
         CloseSocket(hSocket);
         return error("Hostname too long");
     }
-    char pszSocks5Init[] = "\5\1\0";
-    ssize_t nSize = sizeof(pszSocks5Init) - 1;
-
-    ssize_t ret = send(hSocket, pszSocks5Init, nSize, MSG_NOSIGNAL);
-    if (ret != nSize)
-    {
+    // Accepted authentication methods
+    std::vector<uint8_t> vSocks5Init;
+    vSocks5Init.push_back(0x05);
+    if (auth) {
+        vSocks5Init.push_back(0x02); // # METHODS
+        vSocks5Init.push_back(0x00); // X'00' NO AUTHENTICATION REQUIRED
+        vSocks5Init.push_back(0x02); // X'02' USERNAME/PASSWORD (RFC1929)
+    } else {
+        vSocks5Init.push_back(0x01); // # METHODS
+        vSocks5Init.push_back(0x00); // X'00' NO AUTHENTICATION REQUIRED
+    }
+    ssize_t ret = send(hSocket, (const char*)begin_ptr(vSocks5Init), vSocks5Init.size(), MSG_NOSIGNAL);
+    if (ret != (ssize_t)vSocks5Init.size()) {
         CloseSocket(hSocket);
         return error("Error sending to proxy");
     }
     char pchRet1[2];
-    if (!InterruptibleRecv(pchRet1, 2, SOCKS5_RECV_TIMEOUT, hSocket))
-    {
+    if (!InterruptibleRecv(pchRet1, 2, SOCKS5_RECV_TIMEOUT, hSocket)) {
         CloseSocket(hSocket);
         return error("Error reading proxy response");
     }
-    if (pchRet1[0] != 0x05 || pchRet1[1] != 0x00)
-    {
+    if (pchRet1[0] != 0x05) {
         CloseSocket(hSocket);
         return error("Proxy failed to initialize");
     }
-    string strSocks5("\5\1");
-    strSocks5 += '\000'; strSocks5 += '\003';
-    strSocks5 += static_cast<char>(std::min((int)strDest.size(), 255));
-    strSocks5 += strDest;
-    strSocks5 += static_cast<char>((port >> 8) & 0xFF);
-    strSocks5 += static_cast<char>((port >> 0) & 0xFF);
-    ret = send(hSocket, strSocks5.data(), strSocks5.size(), MSG_NOSIGNAL);
-    if (ret != (ssize_t)strSocks5.size())
-    {
+    if (pchRet1[1] == 0x02 && auth) {
+        // Perform username/password authentication (as described in RFC1929)
+        std::vector<uint8_t> vAuth;
+        vAuth.push_back(0x01);
+        if (auth->username.size() > 255 || auth->password.size() > 255)
+            return error("Proxy username or password too long");
+        vAuth.push_back(auth->username.size());
+        vAuth.insert(vAuth.end(), auth->username.begin(), auth->username.end());
+        vAuth.push_back(auth->password.size());
+        vAuth.insert(vAuth.end(), auth->password.begin(), auth->password.end());
+        ret = send(hSocket, (const char*)begin_ptr(vAuth), vAuth.size(), MSG_NOSIGNAL);
+        if (ret != (ssize_t)vAuth.size()) {
+            CloseSocket(hSocket);
+            return error("Error sending authentication to proxy");
+        }
+        LogPrint("proxy", "SOCKS5 sending proxy authentication %s:%s\n", auth->username, auth->password);
+        char pchRetA[2];
+        if (!InterruptibleRecv(pchRetA, 2, SOCKS5_RECV_TIMEOUT, hSocket)) {
+            CloseSocket(hSocket);
+            return error("Error reading proxy authentication response");
+        }
+        if (pchRetA[0] != 0x01 || pchRetA[1] != 0x00) {
+            CloseSocket(hSocket);
+            return error("Proxy authentication unsuccesful");
+        }
+    } else if (pchRet1[1] == 0x00) {
+        // Perform no authentication
+    } else {
+        CloseSocket(hSocket);
+        return error("Proxy requested wrong authentication method %02x", pchRet1[1]);
+    }
+    std::vector<uint8_t> vSocks5;
+    vSocks5.push_back(0x05); // VER protocol version
+    vSocks5.push_back(0x01); // CMD CONNECT
+    vSocks5.push_back(0x00); // RSV Reserved
+    vSocks5.push_back(0x03); // ATYP DOMAINNAME
+    vSocks5.push_back(strDest.size()); // Length<=255 is checked at beginning of function
+    vSocks5.insert(vSocks5.end(), strDest.begin(), strDest.end());
+    vSocks5.push_back((port >> 8) & 0xFF);
+    vSocks5.push_back((port >> 0) & 0xFF);
+    ret = send(hSocket, (const char*)begin_ptr(vSocks5), vSocks5.size(), MSG_NOSIGNAL);
+    if (ret != (ssize_t)vSocks5.size()) {
         CloseSocket(hSocket);
         return error("Error sending to proxy");
     }
     char pchRet2[4];
-    if (!InterruptibleRecv(pchRet2, 4, SOCKS5_RECV_TIMEOUT, hSocket))
-    {
+    if (!InterruptibleRecv(pchRet2, 4, SOCKS5_RECV_TIMEOUT, hSocket)) {
         CloseSocket(hSocket);
         return error("Error reading proxy response");
     }
-    if (pchRet2[0] != 0x05)
-    {
+    if (pchRet2[0] != 0x05) {
         CloseSocket(hSocket);
         return error("Proxy failed to accept request");
     }
-    if (pchRet2[1] != 0x00)
-    {
+    if (pchRet2[1] != 0x00) {
         CloseSocket(hSocket);
         switch (pchRet2[1])
         {
@@ -352,8 +394,7 @@ bool static Socks5(string strDest, int port, SOCKET& hSocket)
             default:   return error("Proxy error: unknown");
         }
     }
-    if (pchRet2[2] != 0x00)
-    {
+    if (pchRet2[2] != 0x00) {
         CloseSocket(hSocket);
         return error("Error: malformed proxy response");
     }
@@ -375,13 +416,11 @@ bool static Socks5(string strDest, int port, SOCKET& hSocket)
         }
         default: CloseSocket(hSocket); return error("Error: malformed proxy response");
     }
-    if (!ret)
-    {
+    if (!ret) {
         CloseSocket(hSocket);
         return error("Error reading from proxy");
     }
-    if (!InterruptibleRecv(pchRet3, 2, SOCKS5_RECV_TIMEOUT, hSocket))
-    {
+    if (!InterruptibleRecv(pchRet3, 2, SOCKS5_RECV_TIMEOUT, hSocket)) {
         CloseSocket(hSocket);
         return error("Error reading from proxy");
     }
@@ -471,7 +510,7 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRe
     return true;
 }
 
-bool SetProxy(enum Network net, CService addrProxy) {
+bool SetProxy(enum Network net, const proxyType &addrProxy) {
     assert(net >= 0 && net < NET_MAX);
     if (!addrProxy.IsValid())
         return false;
@@ -489,7 +528,7 @@ bool GetProxy(enum Network net, proxyType &proxyInfoOut) {
     return true;
 }
 
-bool SetNameProxy(CService addrProxy) {
+bool SetNameProxy(const proxyType &addrProxy) {
     if (!addrProxy.IsValid())
         return false;
     LOCK(cs_proxyInfos);
@@ -497,7 +536,7 @@ bool SetNameProxy(CService addrProxy) {
     return true;
 }
 
-bool GetNameProxy(CService &nameProxyOut) {
+bool GetNameProxy(proxyType &nameProxyOut) {
     LOCK(cs_proxyInfos);
     if(!nameProxy.IsValid())
         return false;
@@ -513,10 +552,35 @@ bool HaveNameProxy() {
 bool IsProxy(const CNetAddr &addr) {
     LOCK(cs_proxyInfos);
     for (int i = 0; i < NET_MAX; i++) {
-        if (addr == (CNetAddr)proxyInfo[i])
+        if (addr == (CNetAddr)proxyInfo[i].proxy)
             return true;
     }
     return false;
+}
+
+static bool ConnectThroughProxy(const proxyType &proxy, const std::string strDest, int port, SOCKET& hSocketRet, int nTimeout, bool *outProxyConnectionFailed)
+{
+    SOCKET hSocket = INVALID_SOCKET;
+    // first connect to proxy server
+    if (!ConnectSocketDirectly(proxy.proxy, hSocket, nTimeout)) {
+        if (outProxyConnectionFailed)
+            *outProxyConnectionFailed = true;
+        return false;
+    }
+    // do socks negotiation
+    if (proxy.randomize_credentials) {
+        ProxyCredentials random_auth;
+        random_auth.username = strprintf("%i", insecure_rand());
+        random_auth.password = strprintf("%i", insecure_rand());
+        if (!Socks5(strDest, (unsigned short)port, &random_auth, hSocket))
+            return false;
+    } else {
+        if (!Socks5(strDest, (unsigned short)port, 0, hSocket))
+            return false;
+    }
+
+    hSocketRet = hSocket;
+    return true;
 }
 
 bool ConnectSocket(const CService &addrDest, SOCKET& hSocketRet, int nTimeout, bool *outProxyConnectionFailed)
@@ -524,24 +588,11 @@ bool ConnectSocket(const CService &addrDest, SOCKET& hSocketRet, int nTimeout, b
     proxyType proxy;
     if (outProxyConnectionFailed)
         *outProxyConnectionFailed = false;
-    // no proxy needed (none set for target network)
-    if (!GetProxy(addrDest.GetNetwork(), proxy))
+
+    if (GetProxy(addrDest.GetNetwork(), proxy))
+        return ConnectThroughProxy(proxy, addrDest.ToStringIP(), addrDest.GetPort(), hSocketRet, nTimeout, outProxyConnectionFailed);
+    else // no proxy needed (none set for target network)
         return ConnectSocketDirectly(addrDest, hSocketRet, nTimeout);
-
-    SOCKET hSocket = INVALID_SOCKET;
-
-    // first connect to proxy server
-    if (!ConnectSocketDirectly(proxy, hSocket, nTimeout)) {
-        if (outProxyConnectionFailed)
-            *outProxyConnectionFailed = true;
-        return false;
-    }
-    // do socks negotiation
-    if (!Socks5(addrDest.ToStringIP(), addrDest.GetPort(), hSocket))
-        return false;
-
-    hSocketRet = hSocket;
-    return true;
 }
 
 bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest, int portDefault, int nTimeout, bool *outProxyConnectionFailed)
@@ -554,9 +605,7 @@ bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest
 
     SplitHostPort(string(pszDest), port, strDest);
 
-    SOCKET hSocket = INVALID_SOCKET;
-
-    CService nameProxy;
+    proxyType nameProxy;
     GetNameProxy(nameProxy);
 
     CService addrResolved(CNetAddr(strDest, fNameLookup && !HaveNameProxy()), port);
@@ -569,18 +618,7 @@ bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest
 
     if (!HaveNameProxy())
         return false;
-    // first connect to name proxy server
-    if (!ConnectSocketDirectly(nameProxy, hSocket, nTimeout)) {
-        if (outProxyConnectionFailed)
-            *outProxyConnectionFailed = true;
-        return false;
-    }
-    // do socks negotiation
-    if (!Socks5(strDest, (unsigned short)port, hSocket))
-        return false;
-
-    hSocketRet = hSocket;
-    return true;
+    return ConnectThroughProxy(nameProxy, strDest, port, hSocketRet, nTimeout, outProxyConnectionFailed);
 }
 
 void CNetAddr::Init()

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -168,15 +168,25 @@ class CService : public CNetAddr
         }
 };
 
-typedef CService proxyType;
+class proxyType
+{
+public:
+    proxyType(): randomize_credentials(false) {}
+    proxyType(const CService &proxy, bool randomize_credentials=false): proxy(proxy), randomize_credentials(randomize_credentials) {}
+
+    bool IsValid() const { return proxy.IsValid(); }
+
+    CService proxy;
+    bool randomize_credentials;
+};
 
 enum Network ParseNetwork(std::string net);
 std::string GetNetworkName(enum Network net);
 void SplitHostPort(std::string in, int &portOut, std::string &hostOut);
-bool SetProxy(enum Network net, CService addrProxy);
+bool SetProxy(enum Network net, const proxyType &addrProxy);
 bool GetProxy(enum Network net, proxyType &proxyInfoOut);
 bool IsProxy(const CNetAddr &addr);
-bool SetNameProxy(CService addrProxy);
+bool SetNameProxy(const proxyType &addrProxy);
 bool HaveNameProxy();
 bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions = 0, bool fAllowLookup = true);
 bool Lookup(const char *pszName, CService& addr, int portDefault = 0, bool fAllowLookup = true);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -335,8 +335,8 @@ bool OptionsModel::getProxySettings(QNetworkProxy& proxy) const
     proxyType curProxy;
     if (GetProxy(NET_IPV4, curProxy)) {
         proxy.setType(QNetworkProxy::Socks5Proxy);
-        proxy.setHostName(QString::fromStdString(curProxy.ToStringIP()));
-        proxy.setPort(curProxy.GetPort());
+        proxy.setHostName(QString::fromStdString(curProxy.proxy.ToStringIP()));
+        proxy.setPort(curProxy.proxy.GetPort());
 
         return true;
     }

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -90,7 +90,7 @@ Value getinfo(const Array& params, bool fHelp)
     obj.push_back(Pair("blocks",        (int)chainActive.Height()));
     obj.push_back(Pair("timeoffset",    GetTimeOffset()));
     obj.push_back(Pair("connections",   (int)vNodes.size()));
-    obj.push_back(Pair("proxy",         (proxy.IsValid() ? proxy.ToStringIPPort() : string())));
+    obj.push_back(Pair("proxy",         (proxy.IsValid() ? proxy.proxy.ToStringIPPort() : string())));
     obj.push_back(Pair("difficulty",    (double)GetDifficulty()));
     obj.push_back(Pair("testnet",       Params().TestnetToBeDeprecatedFieldRPC()));
 #ifdef ENABLE_WALLET

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -371,7 +371,8 @@ static Array GetNetworksInfo()
         obj.push_back(Pair("name", GetNetworkName(network)));
         obj.push_back(Pair("limited", IsLimited(network)));
         obj.push_back(Pair("reachable", IsReachable(network)));
-        obj.push_back(Pair("proxy", proxy.IsValid() ? proxy.ToStringIPPort() : string()));
+        obj.push_back(Pair("proxy", proxy.IsValid() ? proxy.proxy.ToStringIPPort() : string()));
+        obj.push_back(Pair("proxy_randomize_credentials", proxy.randomize_credentials));
         networks.push_back(obj);
     }
     return networks;


### PR DESCRIPTION
This adds a -prune=N option to bitcoind, which if set to N>0 will enable block
file pruning. When pruning is enabled, block and undo files will be deleted to
try to keep total space used by those files to below the prune target (N, in
MB) specified by the user, subject to some constraints:
- The last 288 blocks on the main chain are always kept (MIN_BLOCKS_TO_KEEP),
- N must be at least 550MB (chosen as a value for the target that could
  reasonably be met, with some assumptions about block sizes, orphan rates,
  etc; see comment in main.h),
- No blocks are pruned until chainActive is at least 100,000 blocks long (on
  mainnet; defined separately for mainnet, testnet, and regtest in chainparams
  as nPruneAfterHeight).

This unsets NODE_NETWORK if pruning is enabled.

Also included is an RPC test for pruning (pruning.py).

Thanks to @rdponticelli for earlier work on this feature; this is based in
part off that work.
